### PR TITLE
feat: Update plan workflow to output in Japanese

### DIFF
--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -161,11 +161,17 @@
 #
 # Review instructions in `.github/instructions/*.instructions.md` if you need guidance.
 #
+# ## Language
+#
+# **All output must be in Japanese (日本語)**: Issue titles, bodies, comments, and all other text must be written in Japanese.
+#
 # ## Begin Planning
 #
 # Analyze the issue or discussion and create the sub-issues now. Remember to use the safe-outputs mechanism to create each issue. Each sub-issue you create will be automatically linked to the parent (issue #${{ github.event.issue.number }} or discussion #${{ github.event.discussion.number }}).
 #
 # After creating all the sub-issues successfully, if this was triggered from a discussion in the "Ideas" category, close the discussion with a comment summarizing the plan and resolution reason "RESOLVED".
+#
+# **Important: Write all content in Japanese.**
 # ```
 #
 # Pinned GitHub Actions:
@@ -1763,11 +1769,17 @@ jobs:
           
           Review instructions in `.github/instructions/*.instructions.md` if you need guidance.
           
+          ## Language
+          
+          **All output must be in Japanese (日本語)**: Issue titles, bodies, comments, and all other text must be written in Japanese.
+          
           ## Begin Planning
           
           Analyze the issue or discussion and create the sub-issues now. Remember to use the safe-outputs mechanism to create each issue. Each sub-issue you create will be automatically linked to the parent (issue #${GH_AW_EXPR_9C6DBB26} or discussion #${GH_AW_EXPR_2497EEDF}).
           
           After creating all the sub-issues successfully, if this was triggered from a discussion in the "Ideas" category, close the discussion with a comment summarizing the plan and resolution reason "RESOLVED".
+          
+          **Important: Write all content in Japanese.**
           
           PROMPT_EOF
       - name: Append XPIA security instructions to prompt

--- a/.github/workflows/plan.md
+++ b/.github/workflows/plan.md
@@ -135,8 +135,14 @@ This is needed to secure API endpoints before implementing user-specific feature
 
 Review instructions in `.github/instructions/*.instructions.md` if you need guidance.
 
+## Language
+
+**All output must be in Japanese (日本語)**: Issue titles, bodies, comments, and all other text must be written in Japanese.
+
 ## Begin Planning
 
 Analyze the issue or discussion and create the sub-issues now. Remember to use the safe-outputs mechanism to create each issue. Each sub-issue you create will be automatically linked to the parent (issue #${{ github.event.issue.number }} or discussion #${{ github.event.discussion.number }}).
 
 After creating all the sub-issues successfully, if this was triggered from a discussion in the "Ideas" category, close the discussion with a comment summarizing the plan and resolution reason "RESOLVED".
+
+**Important: Write all content in Japanese.**


### PR DESCRIPTION
## 変更内容
plan.md ワークフローを更新して、作成されるissueとコメントをすべて日本語で出力するようにしました。

## 変更点
- プロンプトに日本語出力の指示を追加
- AIエージェントが作成するissue、コメント、その他のテキストをすべて日本語化

## テスト
- ワークフローのコンパイルが成功することを確認済み